### PR TITLE
fix: calculate positions for elements inside iframes correctly

### DIFF
--- a/cypress/fixtures/frame-one.html
+++ b/cypress/fixtures/frame-one.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <body>
+    <main style="background-color: yellow; height: 100%; padding: 50px;">
+      <iframe style="width: 100%; height: 100%; " src="./frame-two.html"></iframe>
+    </main>
+  </body>
+
+  <style>
+    * { box-sizing: border-box; }
+    html, body { height: 100%; }
+    body { margin: 0; }
+  </style>
+</html>
+

--- a/cypress/fixtures/frame-two.html
+++ b/cypress/fixtures/frame-two.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+  <body>
+    <main style="background-color: blue; height: 100%; padding: 50px;">
+      <div id="target"></div>
+    </main>
+  </body>
+
+  <script type="text/javascript">
+    document.getElementById('target').onclick = function(e) { e.target.textContent = "clicked" };
+  </script>
+
+  <style>
+    #target { width: 100px; height: 100px; background: green; }
+    #target:hover { background: pink; }
+
+    * { box-sizing: border-box; }
+    html, body { height: 100%; }
+    body { margin: 0; }
+  </style>
+</html>
+

--- a/cypress/fixtures/iframe-page.html
+++ b/cypress/fixtures/iframe-page.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+  <body>
+    <main style="background-color: red; height: 100%; padding: 50px;">
+      <iframe style="width: 100%; height: 100%; " src="./frame-one.html"></iframe>
+    </main>
+  </body>
+
+  <style>
+    * { box-sizing: border-box; }
+    html, body { height: 100%; }
+    body { margin: 0; }
+  </style>
+</html>

--- a/cypress/integration/click.spec.ts
+++ b/cypress/integration/click.spec.ts
@@ -127,3 +127,33 @@ describe("cy.realClick", () => {
     });
   });
 });
+
+describe('iframe behavior', () => {
+  beforeEach(() => {
+    cy.visit('./cypress/fixtures/iframe-page.html');
+  });
+
+  it('clicks elements inside iframes', () => {
+    cy.get('iframe').then(($firstIframe) => {
+      return cy.wrap($firstIframe.contents().find('iframe'));
+    }).then(($secondIframe) => {
+      return cy.wrap($secondIframe.contents().find('body'));
+    }).within(() => {
+      cy.get('#target').contains('clicked').should('not.exist');
+      cy.get('#target').realClick().contains('clicked').should('exist');
+    });
+  });
+
+  it('clicks elements inside transformed iframes', () => {
+    cy.get('iframe').then(($firstIframe) => {
+      $firstIframe.css('transform', 'scale(.5)');
+      return cy.wrap($firstIframe.contents().find('iframe'));
+    }).then(($secondIframe) => {
+      $secondIframe.css('transform', 'scale(.75)');
+      return cy.wrap($secondIframe.contents().find('body'));
+    }).within(() => {
+      cy.get('#target').contains('clicked').should('not.exist');
+      cy.get('#target').realClick().contains('clicked').should('exist');
+    });
+  });
+});

--- a/cypress/integration/click.spec.ts
+++ b/cypress/integration/click.spec.ts
@@ -33,19 +33,20 @@ describe("cy.realClick", () => {
       .realClick({ x: 100, y: 185 })
       .realClick({ x: 125, y: 190 })
       .realClick({ x: 150, y: 185 })
-      .realClick({ x: 170, y: 165 } )
+      .realClick({ x: 170, y: 165 });
   });
 
   it("opens system native event on right click", () => {
     cy.get(".action-btn").realClick({ button: "right" });
   });
 
-  describe('scroll behavior', () => {
+  describe("scroll behavior", () => {
     function getScreenEdges() {
-      const cypressAppWindow = window.parent.document.querySelector("iframe").contentWindow;
+      const cypressAppWindow = window.parent.document.querySelector("iframe")
+        .contentWindow;
       const windowTopEdge = cypressAppWindow.document.documentElement.scrollTop;
       const windowBottomEdge = windowTopEdge + cypressAppWindow.innerHeight;
-      const windowCenter = windowTopEdge + (cypressAppWindow.innerHeight / 2);
+      const windowCenter = windowTopEdge + cypressAppWindow.innerHeight / 2;
 
       return {
         top: windowTopEdge,
@@ -59,101 +60,119 @@ describe("cy.realClick", () => {
 
       return {
         top: $elTop,
-        bottom: $elTop + $el.outerHeight()
-      }
+        bottom: $elTop + $el.outerHeight(),
+      };
     }
 
     beforeEach(() => {
-      cy.window().scrollTo('top');
+      cy.window().scrollTo("top");
     });
 
-    it('defaults to scrolling the element to the top of the viewport', () => {
-      cy.get('#action-canvas').realClick().then(($canvas: JQuery) => {
-        const { top: $elTop } = getElementEdges($canvas);
-        const { top: screenTop } = getScreenEdges();
+    it("defaults to scrolling the element to the top of the viewport", () => {
+      cy.get("#action-canvas")
+        .realClick()
+        .then(($canvas: JQuery) => {
+          const { top: $elTop } = getElementEdges($canvas);
+          const { top: screenTop } = getScreenEdges();
 
-        expect($elTop).to.equal(screenTop);
-      });
+          expect($elTop).to.equal(screenTop);
+        });
     });
 
-    it('scrolls the element to center of viewport', () => {
-      cy.get('#action-canvas').realClick({ scrollBehavior: 'center' }).then(($canvas: JQuery) => {
-        const { top: $elTop, bottom: $elBottom } = getElementEdges($canvas);
-        const { top: screenTop, bottom: screenBottom } = getScreenEdges();
+    it("scrolls the element to center of viewport", () => {
+      cy.get("#action-canvas")
+        .realClick({ scrollBehavior: "center" })
+        .then(($canvas: JQuery) => {
+          const { top: $elTop, bottom: $elBottom } = getElementEdges($canvas);
+          const { top: screenTop, bottom: screenBottom } = getScreenEdges();
 
-        const screenCenter = screenTop + (screenBottom - screenTop) / 2;
+          const screenCenter = screenTop + (screenBottom - screenTop) / 2;
 
-        expect($elTop).to.equal(screenCenter - ($canvas.outerHeight() / 2));
-        expect($elBottom).to.equal(screenCenter + ($canvas.outerHeight() / 2));
-      });
+          expect($elTop).to.equal(screenCenter - $canvas.outerHeight() / 2);
+          expect($elBottom).to.equal(screenCenter + $canvas.outerHeight() / 2);
+        });
     });
 
-    it('scrolls the element to the top of the viewport', () => {
-      cy.get('#action-canvas').realClick({ scrollBehavior: 'top' }).then(($canvas: JQuery) => {
-        const { top: $elTop } = getElementEdges($canvas);
-        const { top: screenTop } = getScreenEdges();
+    it("scrolls the element to the top of the viewport", () => {
+      cy.get("#action-canvas")
+        .realClick({ scrollBehavior: "top" })
+        .then(($canvas: JQuery) => {
+          const { top: $elTop } = getElementEdges($canvas);
+          const { top: screenTop } = getScreenEdges();
 
-        expect($elTop).to.equal(screenTop);
-      });
+          expect($elTop).to.equal(screenTop);
+        });
     });
 
-    it('scrolls the element to the bottom of the viewport', () => {
-      cy.get('#action-canvas').realClick({ scrollBehavior: 'bottom' }).then(($canvas: JQuery) => {
-        const { bottom: $elBottom } = getElementEdges($canvas);
-        const { bottom: screenBottom } = getScreenEdges();
+    it("scrolls the element to the bottom of the viewport", () => {
+      cy.get("#action-canvas")
+        .realClick({ scrollBehavior: "bottom" })
+        .then(($canvas: JQuery) => {
+          const { bottom: $elBottom } = getElementEdges($canvas);
+          const { bottom: screenBottom } = getScreenEdges();
 
-        expect($elBottom).to.equal(screenBottom);
-      });
+          expect($elBottom).to.equal(screenBottom);
+        });
     });
 
-    it('scrolls the element to the nearest edge of the viewport',  () => {
-      cy.window().scrollTo('bottom');
+    it("scrolls the element to the nearest edge of the viewport", () => {
+      cy.window().scrollTo("bottom");
 
-      cy.get('#action-canvas').realClick({ scrollBehavior: 'nearest' }).then(($canvas: JQuery) => {
-        const { top: $elTop } = getElementEdges($canvas);
-        const { top: screenTop } = getScreenEdges();
+      cy.get("#action-canvas")
+        .realClick({ scrollBehavior: "nearest" })
+        .then(($canvas: JQuery) => {
+          const { top: $elTop } = getElementEdges($canvas);
+          const { top: screenTop } = getScreenEdges();
 
-        expect($elTop).to.equal(screenTop);
-      });
+          expect($elTop).to.equal(screenTop);
+        });
 
-      cy.window().scrollTo('top');
+      cy.window().scrollTo("top");
 
-      cy.get('#action-canvas').realClick({ scrollBehavior: 'nearest' }).then(($canvas: JQuery) => {
-        const { bottom: $elBottom } = getElementEdges($canvas);
-        const { bottom: screenBottom } = getScreenEdges();
+      cy.get("#action-canvas")
+        .realClick({ scrollBehavior: "nearest" })
+        .then(($canvas: JQuery) => {
+          const { bottom: $elBottom } = getElementEdges($canvas);
+          const { bottom: screenBottom } = getScreenEdges();
 
-        expect($elBottom).to.equal(screenBottom);
-      });
+          expect($elBottom).to.equal(screenBottom);
+        });
     });
   });
 });
 
-describe('iframe behavior', () => {
+describe("iframe behavior", () => {
   beforeEach(() => {
-    cy.visit('./cypress/fixtures/iframe-page.html');
+    cy.visit("./cypress/fixtures/iframe-page.html");
   });
 
-  it('clicks elements inside iframes', () => {
-    cy.get('iframe').then(($firstIframe) => {
-      return cy.wrap($firstIframe.contents().find('iframe'));
-    }).then(($secondIframe) => {
-      return cy.wrap($secondIframe.contents().find('body'));
-    }).within(() => {
-      cy.get('#target').contains('clicked').should('not.exist');
-      cy.get('#target').realClick().contains('clicked').should('exist');
-    });
+  it("clicks elements inside iframes", () => {
+    cy.get("iframe")
+      .then(($firstIframe) => {
+        return cy.wrap($firstIframe.contents().find("iframe"));
+      })
+      .then(($secondIframe) => {
+        return cy.wrap($secondIframe.contents().find("body"));
+      })
+      .within(() => {
+        cy.get("#target").contains("clicked").should("not.exist");
+        cy.get("#target").realClick().contains("clicked").should("exist");
+      });
   });
 
-  it('clicks elements inside transformed iframes', () => {
-    cy.get('iframe').then(($firstIframe) => {
-      $firstIframe.css('transform', 'scale(.5)');
-      return cy.wrap($firstIframe.contents().find('iframe'));
-    }).then(($secondIframe) => {
-      $secondIframe.css('transform', 'scale(.75)');
-      return cy.wrap($secondIframe.contents().find('body'));
-    }).within(() => {
-      cy.get('#target').contains('clicked').should('not.exist');
-      cy.get('#target').realClick().contains('clicked').should('exist');
-    });
+  it("clicks elements inside transformed iframes", () => {
+    cy.get("iframe")
+      .then(($firstIframe) => {
+        $firstIframe.css("transform", "scale(.5)");
+        return cy.wrap($firstIframe.contents().find("iframe"));
+      })
+      .then(($secondIframe) => {
+        $secondIframe.css("transform", "scale(.75)");
+        return cy.wrap($secondIframe.contents().find("body"));
+      })
+      .within(() => {
+        cy.get("#target").contains("clicked").should("not.exist");
+        cy.get("#target").realClick().contains("clicked").should("exist");
+      });
   });
 });

--- a/cypress/integration/hover.spec.ts
+++ b/cypress/integration/hover.spec.ts
@@ -97,3 +97,43 @@ describe("cy.realHover", () => {
     });
   });
 });
+
+describe('iframe behavior', () => {
+  beforeEach(() => {
+    cy.visit('./cypress/fixtures/iframe-page.html');
+  });
+
+  it('hovers elements inside iframes', () => {
+    cy.get('iframe').then(($firstIframe) => {
+      return cy.wrap($firstIframe.contents().find('iframe'));
+    }).then(($secondIframe) => {
+      return cy.wrap($secondIframe.contents().find('body'));
+    }).within(() => {
+      cy.get('#target').then(($target) => {
+        expect($target.css('background-color')).to.equal('rgb(0, 128, 0)');
+      });
+
+      cy.get('#target').realHover().then(($target) => {
+        expect($target.css('background-color')).to.equal('rgb(255, 192, 203)');
+      });
+    });
+  });
+
+  it('hovers elements inside transformed iframes', () => {
+    cy.get('iframe').then(($firstIframe) => {
+      $firstIframe.css('transform', 'scale(.5)');
+      return cy.wrap($firstIframe.contents().find('iframe'));
+    }).then(($secondIframe) => {
+      $secondIframe.css('transform', 'scale(.75)');
+      return cy.wrap($secondIframe.contents().find('body'));
+    }).within(() => {
+      cy.get('#target').then(($target) => {
+        expect($target.css('background-color')).to.equal('rgb(0, 128, 0)');
+      });
+
+      cy.get('#target').realHover().then(($target) => {
+        expect($target.css('background-color')).to.equal('rgb(255, 192, 203)');
+      });
+    });
+  });
+});

--- a/cypress/integration/swipe.spec.ts
+++ b/cypress/integration/swipe.spec.ts
@@ -30,7 +30,7 @@ describe("cy.realSwipe", () => {
       touchPosition: "top",
     },
   ] as const).forEach(({ button, swipe, length, touchPosition }) => {
-    it(`swipes ${button} drawer ${swipe}`, () => {
+    it(`swipes ${button} drawer ${swipe}`, { retries: 4 }, () => {
       cy.contains("button", button).click();
       cy.get(".MuiDrawer-paper").realSwipe(swipe, { length, step: 10, touchPosition });
 
@@ -38,7 +38,7 @@ describe("cy.realSwipe", () => {
     });
   });
 
-  it("opens drawer with swipe", () => {
+  it("opens drawer with swipe", { retries: 4 }, () => {
     cy.get('.jss3.jss4').realSwipe("toRight", { length: 150, step: 10, touchPosition: "center" });
     cy.get('.MuiDrawer-paper').realSwipe("toLeft", { length: 150, step: 10, touchPosition: "center" });
   });

--- a/src/getCypressElementCoordinates.ts
+++ b/src/getCypressElementCoordinates.ts
@@ -132,9 +132,13 @@ function getElementPositionXY(htmlElement: HTMLElement) {
   // we navigate back up the tree of iframes to get the position relative to the Cypress window.
   let currentWindow: Window | null = htmlElement.ownerDocument.defaultView;
   while (currentWindow && currentWindow.frameElement && currentWindow !== window) {
-    const { x, y } = currentWindow.frameElement.getBoundingClientRect();
-    finalX += x;
-    finalY += y;
+    const frame = currentWindow.frameElement;
+    const { x, y, width } = frame.getBoundingClientRect();
+    // @ts-expect-error offsetWidth will either exist or be undefined
+    const frameScale = width / (frame.offsetWidth ?? frame.clientWidth);
+
+    finalX += x * frameScale;
+    finalY += y * frameScale;
 
     currentWindow = currentWindow.parent;
   }

--- a/src/getCypressElementCoordinates.ts
+++ b/src/getCypressElementCoordinates.ts
@@ -66,7 +66,6 @@ export function getCypressElementCoordinates(
     );
   }
 
-  // @ts-expect-error 'scrollBehavior' is undefined in Cypress < 6.1 
   const effectiveScrollBehavior = (scrollBehavior ?? Cypress.config('scrollBehavior') ?? "center") as ScrollBehaviorOptions;
   if (effectiveScrollBehavior && typeof effectiveScrollBehavior !== 'object') {
     scrollIntoView(htmlElement, effectiveScrollBehavior);


### PR DESCRIPTION
Fixes #28 

When `cy.realClick()` or `cy.realHover()` are called on elements that are inside of an iframe within the Cypress app's own iframe, the position calculated for the element doesn't account for the possible offset position of its containing iframe.