### PR TITLE
feat: allow changing scrolling behavior for realClick and realHover

### DIFF
--- a/cypress/integration/click.spec.ts
+++ b/cypress/integration/click.spec.ts
@@ -1,3 +1,5 @@
+import scrollBehaviorSpecGenerator from './_scroll-behavior';
+
 describe("cy.realClick", () => {
   beforeEach(() => {
     cy.visit("https://example.cypress.io/commands/actions");
@@ -39,4 +41,6 @@ describe("cy.realClick", () => {
   it("opens system native event on right click", () => {
     cy.get(".action-btn").realClick({ button: "right" });
   });
+
+  scrollBehaviorSpecGenerator('realClick');
 });

--- a/cypress/integration/click.spec.ts
+++ b/cypress/integration/click.spec.ts
@@ -1,5 +1,3 @@
-import scrollBehaviorSpecGenerator from './_scroll-behavior';
-
 describe("cy.realClick", () => {
   beforeEach(() => {
     cy.visit("https://example.cypress.io/commands/actions");
@@ -42,5 +40,90 @@ describe("cy.realClick", () => {
     cy.get(".action-btn").realClick({ button: "right" });
   });
 
-  scrollBehaviorSpecGenerator('realClick');
+  describe('scroll behavior', () => {
+    function getScreenEdges() {
+      const cypressAppWindow = window.parent.document.querySelector("iframe").contentWindow;
+      const windowTopEdge = cypressAppWindow.document.documentElement.scrollTop;
+      const windowBottomEdge = windowTopEdge + cypressAppWindow.innerHeight;
+      const windowCenter = windowTopEdge + (cypressAppWindow.innerHeight / 2);
+
+      return {
+        top: windowTopEdge,
+        bottom: windowBottomEdge,
+        center: windowCenter,
+      };
+    }
+
+    function getElementEdges($el: JQuery) {
+      const $elTop = $el.offset().top;
+
+      return {
+        top: $elTop,
+        bottom: $elTop + $el.outerHeight()
+      }
+    }
+
+    beforeEach(() => {
+      cy.window().scrollTo('top');
+    });
+
+    it('defaults to scrolling the element to the top of the viewport', () => {
+      cy.get('#action-canvas').realClick().then(($canvas: JQuery) => {
+        const { top: $elTop } = getElementEdges($canvas);
+        const { top: screenTop } = getScreenEdges();
+
+        expect($elTop).to.equal(screenTop);
+      });
+    });
+
+    it('scrolls the element to center of viewport', () => {
+      cy.get('#action-canvas').realClick({ scrollBehavior: 'center' }).then(($canvas: JQuery) => {
+        const { top: $elTop, bottom: $elBottom } = getElementEdges($canvas);
+        const { top: screenTop, bottom: screenBottom } = getScreenEdges();
+
+        const screenCenter = screenTop + (screenBottom - screenTop) / 2;
+
+        expect($elTop).to.equal(screenCenter - ($canvas.outerHeight() / 2));
+        expect($elBottom).to.equal(screenCenter + ($canvas.outerHeight() / 2));
+      });
+    });
+
+    it('scrolls the element to the top of the viewport', () => {
+      cy.get('#action-canvas').realClick({ scrollBehavior: 'top' }).then(($canvas: JQuery) => {
+        const { top: $elTop } = getElementEdges($canvas);
+        const { top: screenTop } = getScreenEdges();
+
+        expect($elTop).to.equal(screenTop);
+      });
+    });
+
+    it('scrolls the element to the bottom of the viewport', () => {
+      cy.get('#action-canvas').realClick({ scrollBehavior: 'bottom' }).then(($canvas: JQuery) => {
+        const { bottom: $elBottom } = getElementEdges($canvas);
+        const { bottom: screenBottom } = getScreenEdges();
+
+        expect($elBottom).to.equal(screenBottom);
+      });
+    });
+
+    it('scrolls the element to the nearest edge of the viewport',  () => {
+      cy.window().scrollTo('bottom');
+
+      cy.get('#action-canvas').realClick({ scrollBehavior: 'nearest' }).then(($canvas: JQuery) => {
+        const { top: $elTop } = getElementEdges($canvas);
+        const { top: screenTop } = getScreenEdges();
+
+        expect($elTop).to.equal(screenTop);
+      });
+
+      cy.window().scrollTo('top');
+
+      cy.get('#action-canvas').realClick({ scrollBehavior: 'nearest' }).then(($canvas: JQuery) => {
+        const { bottom: $elBottom } = getElementEdges($canvas);
+        const { bottom: screenBottom } = getScreenEdges();
+
+        expect($elBottom).to.equal(screenBottom);
+      });
+    });
+  });
 });

--- a/cypress/integration/hover.spec.ts
+++ b/cypress/integration/hover.spec.ts
@@ -18,9 +18,9 @@ describe("cy.realHover", () => {
       const windowCenter = windowTopEdge + (cypressAppWindow.innerHeight / 2);
 
       return {
-        top: windowTopEdge,
-        bottom: windowBottomEdge,
-        center: windowCenter,
+        screenTop: windowTopEdge,
+        screenBottom: windowBottomEdge,
+        screenCenter: windowCenter,
       };
     }
 
@@ -28,8 +28,8 @@ describe("cy.realHover", () => {
       const $elTop = $el.offset().top;
 
       return {
-        top: $elTop,
-        bottom: $elTop + $el.outerHeight()
+        $elTop,
+        $elBottom: $elTop + $el.outerHeight()
       }
     }
 
@@ -39,8 +39,8 @@ describe("cy.realHover", () => {
 
     it('defaults to scrolling the element to the top of the viewport', () => {
       cy.get('#action-canvas').realHover().then(($canvas: JQuery) => {
-        const { top: $elTop } = getElementEdges($canvas);
-        const { top: screenTop } = getScreenEdges();
+        const { $elTop } = getElementEdges($canvas);
+        const { screenTop } = getScreenEdges();
 
         expect($elTop).to.equal(screenTop);
       });
@@ -48,8 +48,8 @@ describe("cy.realHover", () => {
 
     it('scrolls the element to center of viewport', () => {
       cy.get('#action-canvas').realHover({ scrollBehavior: 'center' }).then(($canvas: JQuery) => {
-        const { top: $elTop, bottom: $elBottom } = getElementEdges($canvas);
-        const { top: screenTop, bottom: screenBottom } = getScreenEdges();
+        const { $elTop, $elBottom } = getElementEdges($canvas);
+        const { screenTop, screenBottom } = getScreenEdges();
 
         const screenCenter = screenTop + (screenBottom - screenTop) / 2;
 
@@ -60,8 +60,8 @@ describe("cy.realHover", () => {
 
     it('scrolls the element to the top of the viewport', () => {
       cy.get('#action-canvas').realHover({ scrollBehavior: 'top' }).then(($canvas: JQuery) => {
-        const { top: $elTop } = getElementEdges($canvas);
-        const { top: screenTop } = getScreenEdges();
+        const { $elTop } = getElementEdges($canvas);
+        const { screenTop } = getScreenEdges();
 
         expect($elTop).to.equal(screenTop);
       });
@@ -69,8 +69,8 @@ describe("cy.realHover", () => {
 
     it('scrolls the element to the bottom of the viewport', () => {
       cy.get('#action-canvas').realHover({ scrollBehavior: 'bottom' }).then(($canvas: JQuery) => {
-        const { bottom: $elBottom } = getElementEdges($canvas);
-        const { bottom: screenBottom } = getScreenEdges();
+        const { $elBottom } = getElementEdges($canvas);
+        const { screenBottom } = getScreenEdges();
 
         expect($elBottom).to.equal(screenBottom);
       });
@@ -80,8 +80,8 @@ describe("cy.realHover", () => {
       cy.window().scrollTo('bottom');
 
       cy.get('#action-canvas').realHover({ scrollBehavior: 'nearest' }).then(($canvas: JQuery) => {
-        const { top: $elTop } = getElementEdges($canvas);
-        const { top: screenTop } = getScreenEdges();
+        const { $elTop } = getElementEdges($canvas);
+        const { screenTop } = getScreenEdges();
 
         expect($elTop).to.equal(screenTop);
       });
@@ -89,8 +89,8 @@ describe("cy.realHover", () => {
       cy.window().scrollTo('top');
 
       cy.get('#action-canvas').realHover({ scrollBehavior: 'nearest' }).then(($canvas: JQuery) => {
-        const { bottom: $elBottom } = getElementEdges($canvas);
-        const { bottom: screenBottom } = getScreenEdges();
+        const { $elBottom } = getElementEdges($canvas);
+        const {  screenBottom } = getScreenEdges();
 
         expect($elBottom).to.equal(screenBottom);
       });

--- a/cypress/integration/hover.spec.ts
+++ b/cypress/integration/hover.spec.ts
@@ -1,3 +1,5 @@
+import scrollBehaviorSpecGenerator from './_scroll-behavior';
+
 describe("cy.realHover", () => {
   beforeEach(() => {
     cy.visit("https://example.cypress.io/commands/actions");
@@ -9,4 +11,6 @@ describe("cy.realHover", () => {
       .realHover()
       .should("have.css", "background-color", "rgb(201, 48, 44)");
   });
+
+  scrollBehaviorSpecGenerator('realHover');
 });

--- a/cypress/integration/hover.spec.ts
+++ b/cypress/integration/hover.spec.ts
@@ -1,5 +1,3 @@
-import scrollBehaviorSpecGenerator from './_scroll-behavior';
-
 describe("cy.realHover", () => {
   beforeEach(() => {
     cy.visit("https://example.cypress.io/commands/actions");
@@ -12,5 +10,90 @@ describe("cy.realHover", () => {
       .should("have.css", "background-color", "rgb(201, 48, 44)");
   });
 
-  scrollBehaviorSpecGenerator('realHover');
+  describe('scroll behavior', () => {
+    function getScreenEdges() {
+      const cypressAppWindow = window.parent.document.querySelector("iframe").contentWindow;
+      const windowTopEdge = cypressAppWindow.document.documentElement.scrollTop;
+      const windowBottomEdge = windowTopEdge + cypressAppWindow.innerHeight;
+      const windowCenter = windowTopEdge + (cypressAppWindow.innerHeight / 2);
+
+      return {
+        top: windowTopEdge,
+        bottom: windowBottomEdge,
+        center: windowCenter,
+      };
+    }
+
+    function getElementEdges($el: JQuery) {
+      const $elTop = $el.offset().top;
+
+      return {
+        top: $elTop,
+        bottom: $elTop + $el.outerHeight()
+      }
+    }
+
+    beforeEach(() => {
+      cy.window().scrollTo('top');
+    });
+
+    it('defaults to scrolling the element to the top of the viewport', () => {
+      cy.get('#action-canvas').realHover().then(($canvas: JQuery) => {
+        const { top: $elTop } = getElementEdges($canvas);
+        const { top: screenTop } = getScreenEdges();
+
+        expect($elTop).to.equal(screenTop);
+      });
+    });
+
+    it('scrolls the element to center of viewport', () => {
+      cy.get('#action-canvas').realHover({ scrollBehavior: 'center' }).then(($canvas: JQuery) => {
+        const { top: $elTop, bottom: $elBottom } = getElementEdges($canvas);
+        const { top: screenTop, bottom: screenBottom } = getScreenEdges();
+
+        const screenCenter = screenTop + (screenBottom - screenTop) / 2;
+
+        expect($elTop).to.equal(screenCenter - ($canvas.outerHeight() / 2));
+        expect($elBottom).to.equal(screenCenter + ($canvas.outerHeight() / 2));
+      });
+    });
+
+    it('scrolls the element to the top of the viewport', () => {
+      cy.get('#action-canvas').realHover({ scrollBehavior: 'top' }).then(($canvas: JQuery) => {
+        const { top: $elTop } = getElementEdges($canvas);
+        const { top: screenTop } = getScreenEdges();
+
+        expect($elTop).to.equal(screenTop);
+      });
+    });
+
+    it('scrolls the element to the bottom of the viewport', () => {
+      cy.get('#action-canvas').realHover({ scrollBehavior: 'bottom' }).then(($canvas: JQuery) => {
+        const { bottom: $elBottom } = getElementEdges($canvas);
+        const { bottom: screenBottom } = getScreenEdges();
+
+        expect($elBottom).to.equal(screenBottom);
+      });
+    });
+
+    it('scrolls the element to the nearest edge of the viewport',  () => {
+      cy.window().scrollTo('bottom');
+
+      cy.get('#action-canvas').realHover({ scrollBehavior: 'nearest' }).then(($canvas: JQuery) => {
+        const { top: $elTop } = getElementEdges($canvas);
+        const { top: screenTop } = getScreenEdges();
+
+        expect($elTop).to.equal(screenTop);
+      });
+
+      cy.window().scrollTo('top');
+
+      cy.get('#action-canvas').realHover({ scrollBehavior: 'nearest' }).then(($canvas: JQuery) => {
+        const { bottom: $elBottom } = getElementEdges($canvas);
+        const { bottom: screenBottom } = getScreenEdges();
+
+        expect($elBottom).to.equal(screenBottom);
+      });
+    });
+  });
 });

--- a/cypress/integration/swipe.spec.ts
+++ b/cypress/integration/swipe.spec.ts
@@ -10,24 +10,28 @@ describe("cy.realSwipe", () => {
       swipe: "toLeft",
       length: 150,
       touchPosition: "right",
+      scrollBehavior: "center",
     },
     {
       button: "right",
       swipe: "toRight",
       length: 150,
       touchPosition: "left",
+      scrollBehavior: "center",
     },
     {
       button: "top",
       swipe: "toTop",
       length: 300,
       touchPosition: "center",
+      scrollBehavior: "center",
     },
     {
       button: "bottom",
       swipe: "toBottom",
       length: 300,
       touchPosition: "top",
+      scrollBehavior: "center",
     },
   ] as const).forEach(({ button, swipe, length, touchPosition }) => {
     it(`swipes ${button} drawer ${swipe}`, () => {

--- a/cypress/integration/swipe.spec.ts
+++ b/cypress/integration/swipe.spec.ts
@@ -10,28 +10,24 @@ describe("cy.realSwipe", () => {
       swipe: "toLeft",
       length: 150,
       touchPosition: "right",
-      scrollBehavior: "center",
     },
     {
       button: "right",
       swipe: "toRight",
       length: 150,
       touchPosition: "left",
-      scrollBehavior: "center",
     },
     {
       button: "top",
       swipe: "toTop",
       length: 300,
       touchPosition: "center",
-      scrollBehavior: "center",
     },
     {
       button: "bottom",
       swipe: "toBottom",
       length: 300,
       touchPosition: "top",
-      scrollBehavior: "center",
     },
   ] as const).forEach(({ button, swipe, length, touchPosition }) => {
     it(`swipes ${button} drawer ${swipe}`, () => {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.8.2",
     "@typescript-eslint/parser": "^4.8.2",
-    "cypress": "^5.6.0",
+    "cypress": "^6.1.0",
     "eslint": "^7.14.0",
     "eslint-plugin-cypress": "^2.11.2",
     "eslint-plugin-no-only-tests": "^2.4.0",

--- a/src/commands/realClick.ts
+++ b/src/commands/realClick.ts
@@ -1,6 +1,7 @@
 import { fireCdpCommand } from "../fireCdpCommand";
 import {
   getCypressElementCoordinates,
+  ScrollBehaviorOptions,
   Position,
 } from "../getCypressElementCoordinates";
 
@@ -26,6 +27,13 @@ export interface RealClickOptions {
    * cy.get("body").realClick({ x: 11, y: 12 }) // global click by coordinates
    */
   y?: number;
+  /**
+   * Controls how the page is scrolled to bring the subject into view, if needed.
+   * If false, the page will not be scrolled.
+   * @example cy.realHover({ scrollBehavior: "top" });
+   * @example cy.realHover({ scrollBehavior: false });
+   */
+  scrollBehavior?: ScrollBehaviorOptions;
 }
 
 /** @ignore this, update documentation for this function at index.d.ts */
@@ -38,7 +46,7 @@ export async function realClick(
     ? { x: options.x, y: options.y } 
     : options.position;
 
-  const { x, y } = getCypressElementCoordinates(subject, position);
+  const { x, y } = getCypressElementCoordinates(subject, position, options.scrollBehavior);
 
   const log = Cypress.log({
     $el: subject,

--- a/src/commands/realClick.ts
+++ b/src/commands/realClick.ts
@@ -29,11 +29,9 @@ export interface RealClickOptions {
   y?: number;
   /**
    * Controls how the page is scrolled to bring the subject into view, if needed.
-   * If false, the page will not be scrolled.
    * @example cy.realHover({ scrollBehavior: "top" });
-   * @example cy.realHover({ scrollBehavior: false });
    */
-  scrollBehavior?: ScrollBehaviorOptions | false;
+  scrollBehavior?: ScrollBehaviorOptions;
 }
 
 /** @ignore this, update documentation for this function at index.d.ts */

--- a/src/commands/realClick.ts
+++ b/src/commands/realClick.ts
@@ -33,7 +33,7 @@ export interface RealClickOptions {
    * @example cy.realHover({ scrollBehavior: "top" });
    * @example cy.realHover({ scrollBehavior: false });
    */
-  scrollBehavior?: ScrollBehaviorOptions;
+  scrollBehavior?: ScrollBehaviorOptions | false;
 }
 
 /** @ignore this, update documentation for this function at index.d.ts */

--- a/src/commands/realHover.ts
+++ b/src/commands/realHover.ts
@@ -21,7 +21,7 @@ export interface RealHoverOptions {
    * @example cy.realHover({ scrollBehavior: "top" });
    * @example cy.realHover({ scrollBehavior: false });
    */
-  scrollBehavior?: ScrollBehaviorOptions;
+  scrollBehavior?: ScrollBehaviorOptions | false;
 }
 
 /** @ignore this, update documentation for this function at index.d.ts */

--- a/src/commands/realHover.ts
+++ b/src/commands/realHover.ts
@@ -17,11 +17,9 @@ export interface RealHoverOptions {
   position?: Position;
   /**
    * Controls how the page is scrolled to bring the subject into view, if needed.
-   * If false, the page will not be scrolled.
    * @example cy.realHover({ scrollBehavior: "top" });
-   * @example cy.realHover({ scrollBehavior: false });
    */
-  scrollBehavior?: ScrollBehaviorOptions | false;
+  scrollBehavior?: ScrollBehaviorOptions;
 }
 
 /** @ignore this, update documentation for this function at index.d.ts */

--- a/src/commands/realHover.ts
+++ b/src/commands/realHover.ts
@@ -1,6 +1,7 @@
 import { fireCdpCommand } from "../fireCdpCommand";
 import {
   Position,
+  ScrollBehaviorOptions,
   getCypressElementCoordinates,
 } from "../getCypressElementCoordinates";
 
@@ -14,6 +15,13 @@ export interface RealHoverOptions {
    * @example cy.realHover({ position: "topLeft" })
    */
   position?: Position;
+  /**
+   * Controls how the page is scrolled to bring the subject into view, if needed.
+   * If false, the page will not be scrolled.
+   * @example cy.realHover({ scrollBehavior: "top" });
+   * @example cy.realHover({ scrollBehavior: false });
+   */
+  scrollBehavior?: ScrollBehaviorOptions;
 }
 
 /** @ignore this, update documentation for this function at index.d.ts */
@@ -21,7 +29,7 @@ export async function realHover(
   subject: JQuery,
   options: RealHoverOptions = {}
 ) {
-  const { x, y } = getCypressElementCoordinates(subject, options.position);
+  const { x, y } = getCypressElementCoordinates(subject, options.position, options.scrollBehavior);
 
   const log = Cypress.log({
     $el: subject,

--- a/src/getCypressElementCoordinates.ts
+++ b/src/getCypressElementCoordinates.ts
@@ -10,7 +10,9 @@ export type Position =
   | "bottomRight"
   | { x: number; y: number };
 
-  function getPositionedCoordinates(
+export type ScrollBehaviorOptions = false | 'center' | 'top' | 'bottom' | 'nearest';
+
+function getPositionedCoordinates(
   x0: number,
   y0: number,
   width: number,
@@ -52,7 +54,8 @@ export type Position =
  */
 export function getCypressElementCoordinates(
   jqueryEl: JQuery,
-  position: Position | undefined
+  position: Position | undefined,
+  scrollBehavior: ScrollBehaviorOptions = "center"
 ) {
   const htmlElement = jqueryEl.get(0);
   const cypressAppFrame = window.parent.document.querySelector("iframe");
@@ -73,7 +76,10 @@ export function getCypressElementCoordinates(
   // This breaks the coordinates system of the whole tab, so we need to compensate the scale value.
   const appFrameScale = appWidth / cypressAppFrame.offsetWidth;
 
-  htmlElement.scrollIntoView({ block: "center" });
+  if (scrollBehavior) {
+    scrollIntoView(htmlElement, scrollBehavior);
+  }
+
   const { x, y, width, height } = htmlElement.getBoundingClientRect();
   const [posX, posY] = getPositionedCoordinates(
     x,
@@ -87,4 +93,20 @@ export function getCypressElementCoordinates(
     x: appFrameX + (window.pageXOffset + posX) * appFrameScale,
     y: appFrameY + (window.pageYOffset + posY) * appFrameScale,
   };
+}
+
+/**
+ * Scrolls the given htmlElement into view on the page.
+ * The position the element is scrolled to can be customized with scrollBehavior.
+ */
+function scrollIntoView(htmlElement: HTMLElement, scrollBehavior: ScrollBehaviorOptions) {
+    let block: ScrollLogicalPosition = "center";
+
+    if (scrollBehavior === "top") {
+      block = "start";
+    } else if (scrollBehavior === "bottom") {
+      block = "end";
+    }
+
+    htmlElement.scrollIntoView({ block });
 }

--- a/src/getCypressElementCoordinates.ts
+++ b/src/getCypressElementCoordinates.ts
@@ -66,8 +66,10 @@ export function getCypressElementCoordinates(
     );
   }
 
+  // @ts-expect-error Cypress.config('scrollBehavior') type not defined in Cypress <6.1.0
   const effectiveScrollBehavior = scrollBehavior ?? Cypress.config('scrollBehavior') ?? "center";
-  if (effectiveScrollBehavior) {
+  if (effectiveScrollBehavior && typeof effectiveScrollBehavior !== 'object') {
+    // @ts-expect-error Cypress.config('scrollBehavior') type not defined in Cypress <6.1.0
     scrollIntoView(htmlElement, effectiveScrollBehavior);
   }
 

--- a/src/getCypressElementCoordinates.ts
+++ b/src/getCypressElementCoordinates.ts
@@ -55,7 +55,7 @@ function getPositionedCoordinates(
 export function getCypressElementCoordinates(
   jqueryEl: JQuery,
   position: Position | undefined,
-  scrollBehavior: ScrollBehaviorOptions = "center"
+  scrollBehavior?: ScrollBehaviorOptions,
 ) {
   const htmlElement = jqueryEl.get(0);
   const cypressAppFrame = window.parent.document.querySelector("iframe");
@@ -64,6 +64,11 @@ export function getCypressElementCoordinates(
     throw new Error(
       "Can not find cypress application iframe, it looks like critical issue. Please rise an issue on GitHub."
     );
+  }
+
+  const effectiveScrollBehavior = scrollBehavior ?? Cypress.config('scrollBehavior') ?? "center";
+  if (effectiveScrollBehavior) {
+    scrollIntoView(htmlElement, effectiveScrollBehavior);
   }
 
   const {
@@ -75,10 +80,6 @@ export function getCypressElementCoordinates(
   // When the window is too narrow in open mode the application iframe is getting transform: scale(0.x) style in order to fit window
   // This breaks the coordinates system of the whole tab, so we need to compensate the scale value.
   const appFrameScale = appWidth / cypressAppFrame.offsetWidth;
-
-  if (scrollBehavior) {
-    scrollIntoView(htmlElement, scrollBehavior);
-  }
 
   const { x, y, width, height } = htmlElement.getBoundingClientRect();
   const [posX, posY] = getPositionedCoordinates(

--- a/src/getCypressElementCoordinates.ts
+++ b/src/getCypressElementCoordinates.ts
@@ -10,7 +10,7 @@ export type Position =
   | "bottomRight"
   | { x: number; y: number };
 
-export type ScrollBehaviorOptions = false | 'center' | 'top' | 'bottom' | 'nearest';
+export type ScrollBehaviorOptions = 'center' | 'top' | 'bottom' | 'nearest';
 
 function getPositionedCoordinates(
   x0: number,
@@ -55,7 +55,7 @@ function getPositionedCoordinates(
 export function getCypressElementCoordinates(
   jqueryEl: JQuery,
   position: Position | undefined,
-  scrollBehavior?: ScrollBehaviorOptions,
+  scrollBehavior?: ScrollBehaviorOptions | false,
 ) {
   const htmlElement = jqueryEl.get(0);
   const cypressAppFrame = window.parent.document.querySelector("iframe");
@@ -100,13 +100,15 @@ export function getCypressElementCoordinates(
  * Scrolls the given htmlElement into view on the page.
  * The position the element is scrolled to can be customized with scrollBehavior.
  */
-function scrollIntoView(htmlElement: HTMLElement, scrollBehavior: ScrollBehaviorOptions) {
-    let block: ScrollLogicalPosition = "center";
+function scrollIntoView(htmlElement: HTMLElement, scrollBehavior: ScrollBehaviorOptions = 'center') {
+    let block: ScrollLogicalPosition;
 
     if (scrollBehavior === "top") {
       block = "start";
     } else if (scrollBehavior === "bottom") {
       block = "end";
+    } else {
+      block = scrollBehavior;
     }
 
     htmlElement.scrollIntoView({ block });

--- a/src/getCypressElementCoordinates.ts
+++ b/src/getCypressElementCoordinates.ts
@@ -55,7 +55,7 @@ function getPositionedCoordinates(
 export function getCypressElementCoordinates(
   jqueryEl: JQuery,
   position: Position | undefined,
-  scrollBehavior?: ScrollBehaviorOptions | false,
+  scrollBehavior?: ScrollBehaviorOptions,
 ) {
   const htmlElement = jqueryEl.get(0);
   const cypressAppFrame = window.parent.document.querySelector("iframe");
@@ -66,10 +66,8 @@ export function getCypressElementCoordinates(
     );
   }
 
-  // @ts-expect-error Cypress.config('scrollBehavior') type not defined in Cypress <6.1.0
   const effectiveScrollBehavior = scrollBehavior ?? Cypress.config('scrollBehavior') ?? "center";
   if (effectiveScrollBehavior && typeof effectiveScrollBehavior !== 'object') {
-    // @ts-expect-error Cypress.config('scrollBehavior') type not defined in Cypress <6.1.0
     scrollIntoView(htmlElement, effectiveScrollBehavior);
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1221,10 +1221,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@^5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-5.6.0.tgz#6781755c3ddfd644ce3179fcd7389176c0c82280"
-  integrity sha512-cs5vG3E2JLldAc16+5yQxaVRLLqMVya5RlrfPWkC72S5xrlHFdw7ovxPb61s4wYweROKTyH01WQc2PFzwwVvyQ==
+cypress@^6.1.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.4.0.tgz#432c516bf4f1a0f042a6aa1f2c3a4278fa35a8b2"
+  integrity sha512-SrsPsZ4IBterudkoFYBvkQmXOVxclh1/+ytbzpV8AH/D2FA+s2Qy5ISsaRzOFsbQa4KZWoi3AKwREmF1HucYkg==
   dependencies:
     "@cypress/listr-verbose-renderer" "^0.4.1"
     "@cypress/request" "^2.88.5"
@@ -1240,6 +1240,7 @@ cypress@^5.6.0:
     cli-table3 "~0.6.0"
     commander "^5.1.0"
     common-tags "^1.8.0"
+    dayjs "^1.9.3"
     debug "^4.1.1"
     eventemitter2 "^6.4.2"
     execa "^4.0.2"
@@ -1254,7 +1255,7 @@ cypress@^5.6.0:
     lodash "^4.17.19"
     log-symbols "^4.0.0"
     minimist "^1.2.5"
-    moment "^2.27.0"
+    moment "^2.29.1"
     ospath "^1.2.2"
     pretty-bytes "^5.4.1"
     ramda "~0.26.1"
@@ -1281,6 +1282,11 @@ dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
+
+dayjs@^1.9.3:
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.4.tgz#8e544a9b8683f61783f570980a8a80eaf54ab1e2"
+  integrity sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw==
 
 debug@3.1.0:
   version "3.1.0"
@@ -3371,7 +3377,7 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moment@^2.27.0:
+moment@^2.29.1:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==


### PR DESCRIPTION
Closes #26 

cypress-real-event's action commands will scroll the element into view before acting on them. This matches the default behavior of Cypress's own action commands.

However, Cypress gives you the option to change the scrolling behavior, or disable the scrolling entirely. cypress-real-events does not let you do so.

This PR introduces a new parameter for `getCypressElementCoordinates`, called "scrollBehavior", which will either change where the page is scrolled to, or disable scrolling entirely.

The `scrollBehavior` param matches the behavior of [the new `scrollBehavior` option introduced in Cypress 6.1.0](https://docs.cypress.io/guides/references/changelog.html#6-1-0).

The new param defaults to the same behavior as before if omitted, so this shouldn't be a breaking change.