### PR TITLE
feat: Add radius option for realTouch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ If you are using typescript, also add the following to `cypress/tsconfig.json`
 
 ## API
 
-The idea of the commands – they should be as similar as possible to cypress default commands (like `cy.type`), but starts with `real` – `cy.realType`. 
+The idea of the commands – they should be as similar as possible to cypress default commands (like `cy.type`), but starts with `real` – `cy.realType`.
 
 Here is an overview of the available **real** event commands:
 - [cy.realClick](#cyrealclick)
@@ -90,7 +90,7 @@ cy.get("button").realClick();
 cy.get("button").realClick(options);
 ```
 
-Example: 
+Example:
 
 ```js
 cy.get("button").realClick({ position: "topLeft" }) // click on the top left corner of button
@@ -101,11 +101,11 @@ Options:
 
 - `Optional` **button**: \"none\" \| \"left\" \| \"right\" \| \"middle\" \| \"back\" \| \"forward\"
 - `Optional` **pointer**: \"mouse\" \| \"pen\"
-- `Optional` x coordinate to click **x**: number 
+- `Optional` x coordinate to click **x**: number
 - `Optional` y coordinate to click **y**: number
 - `Optional`  **position**: "topLeft" | "top" | "topRight" | "left"  | "center" | "right" | "bottomLeft" | "bottom" | "bottomRight"
 
-> Make sure that `x` and `y` has a bigger priority than `position`. 
+> Make sure that `x` and `y` has a bigger priority than `position`.
 
 ## cy.realHover
 
@@ -124,7 +124,7 @@ Options:
 ## cy.realPress
 
 Fires native press event. It can fire one key event or the "shortcut" like Shift+Control+M.
-Make sure that event is global, it means that it is required to **firstly** focus any control before firing this event. 
+Make sure that event is global, it means that it is required to **firstly** focus any control before firing this event.
 
 ```jsx
 cy.realPress("Tab"); // switch the focus for a11y testing
@@ -154,7 +154,7 @@ cy.get("button").realTouch();
 cy.get("button").realTouch(options);
 ```
 
-##### Usage: 
+##### Usage:
 
 ```js
 cy.get("button").realTouch({ position: "topLeft" }) // touches the top left corner of button
@@ -166,6 +166,9 @@ Options:
 - `Optional` **x**: undefined \| number **`default`** 30
 - `Optional` **y**: undefined \| false \| true **`default`** true
 - `Optional` **position**: "topLeft" | "top" | "topRight" | "left"  | "center" | "right" | "bottomLeft" | "bottom" | "bottomRight"
+- `Optional` **radius**: undefined \| number **`default`** 1
+- `Optional` **radiusX**: undefined \| number **`default`** 1
+- `Optional` **radiusY**: undefined \| number **`default`** 1
 
 ### cy.realType
 
@@ -204,7 +207,7 @@ Options:
 
 Runs a native swipe events. It means that **touch events** will be fired. Actually a sequence of `touchStart` -> `touchMove` -> `touchEnd`. It can perfectly swipe drawers and other tools [like this one](https://csb-dhe0i-qj8xxmx8y.vercel.app/).
 
-> Make sure to enable mobile viewport :) 
+> Make sure to enable mobile viewport :)
 
 
 ```js
@@ -229,7 +232,7 @@ cy.realType(direction, options);
 Options:
 
 - `Optional` **length**: undefined \| number **`default`** 10
-- `Optional` x coordinate to touch **x**: number 
+- `Optional` x coordinate to touch **x**: number
 - `Optional` y coordinate to touch **y**: number
 - `Optional` **touchPosition**: "topLeft" | "top" | "topRight" | "left"  | "center" | "right" | "bottomLeft" | "bottom" | "bottomRight"
 

--- a/src/commands/realTouch.ts
+++ b/src/commands/realTouch.ts
@@ -19,6 +19,24 @@ export interface RealTouchOptions {
    * cy.get("body").realTouch({ x: 11, y: 12 }) // global touch by coordinates
    */
   y?: number;
+  /**  radius of the touch area.
+   * @example
+   * cy.get("canvas").realTouch({ x: 100, y: 115, radius: 10 })
+   * cy.get("body").realTouch({ x: 11, y: 12, radius: 10 }) // global touch by coordinates
+   */
+  radius?: number;
+  /**  specific radius of the X axis of the touch area
+   * @example
+   * cy.get("canvas").realTouch({ x: 100, y: 115, radiusX: 10, radiusY: 20 })
+   * cy.get("body").realTouch({ x: 11, y: 12, radiusX: 10, radiusY: 20 }) // global touch by coordinates
+   */
+  radiusX?: number;
+  /**  specific radius of the Y axis of the touch area
+   * @example
+   * cy.get("canvas").realTouch({ x: 100, y: 115, radiusX: 10, radiusY: 20 })
+   * cy.get("body").realTouch({ x: 11, y: 12, radiusX: 10, radiusY: 20 }) // global touch by coordinates
+   */
+  radiusY?: number;
 }
 
 export async function realTouch(
@@ -28,28 +46,40 @@ export async function realTouch(
   const position = options.x && options.y
     ? { x: options.x, y: options.y }
     : options.position;
+  const radiusX = options.radiusX || options.radius || 1
+  const radiusY = options.radiusY || options.radius || 1
 
-  const elementPoints = getCypressElementCoordinates(subject, position);
+  const elementPoint = getCypressElementCoordinates(subject, position);
 
   const log = Cypress.log({
     $el: subject,
     name: "realTouch",
     consoleProps: () => ({
       "Applied To": subject.get(0),
-      "Absolute Coordinates": [elementPoints],
+      "Absolute Coordinates": [elementPoint],
+      "Touched Area (Radius)": {
+        x: radiusX,
+        y: radiusY,
+      }
     })
   })
 
   log.snapshot("before");
 
+  const touchPoint = {
+    ...elementPoint,
+    radiusX,
+    radiusY
+  }
+
   await fireCdpCommand("Input.dispatchTouchEvent", {
     type: "touchStart",
-    touchPoints: [elementPoints],
+    touchPoints: [touchPoint],
   });
 
   await fireCdpCommand("Input.dispatchTouchEvent", {
     type: "touchEnd",
-    touchPoints: [elementPoints],
+    touchPoints: [touchPoint],
   })
 
   log.snapshot("after").end();


### PR DESCRIPTION
I have wanted to write a test that required `radius` in my project and this is not supported yet so I've jumped into adding support for it. There are some more options that could actually be supported but I'm not interested in any of them so I've not added them: https://chromedevtools.github.io/devtools-protocol/tot/Input/#type-TouchPoint

This is a little bit quirky and I feel like it requires some explanation. I've played around with this and those are my takeaways:
- `radius` actually doesn't impact what gets touched - I could set `radius: 100` without it really catching an element that was too far away from the `{ x, y }`
- so this only impacts what values of those properties are received by event handlers
- and because of that this is actually not multiplied by the [`appFrameScale`](https://github.com/dmtrKovalenko/cypress-real-events/blob/7a80cb7ddb7c6bf56942856c1e3a362f204d53db/src/getCypressElementCoordinates.ts#L82) or anything like that