### PR TITLE
feat(dblclick): allow for double clicks to be performed with `cy.realClick({ clickCount: 2 })`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## Why?
 
-Cypress default events are simulated. That means that all events like `cy.click` or `cy.type` are fired from javascript. That's why these events will be untrusted (`event.isTrusted` will be `false`) and they can behave a little different from real native events. But for some cases it can be impossible to use simulated events, for example to fill a native alert or copy to the clipboard. This plugin solves this problem. 
+Cypress default events are simulated. That means that all events like `cy.click` or `cy.type` are fired from javascript. That's why these events will be untrusted (`event.isTrusted` will be `false`) and they can behave a little different from real native events. But for some cases it can be impossible to use simulated events, for example to fill a native alert or copy to the clipboard. This plugin solves this problem.
 
 <img src="https://forthebadge.com/images/badges/it-works-why.svg">
 
@@ -112,6 +112,7 @@ Options:
 - `Optional` y coordinate to click **y**: number
 - `Optional` **position**: "topLeft" | "top" | "topRight" | "left"  | "center" | "right" | "bottomLeft" | "bottom" | "bottomRight"
 - `Optional` **scrollBehavior**: "center" | "top" | "bottom" | "nearest" | false
+- `Optional` **clickCount**: number
 
 > Make sure that `x` and `y` has a bigger priority than `position`.
 
@@ -125,7 +126,7 @@ cy.get("button").realHover(options);
 ```
 
 Example:
-   
+
 ```js
 cy.get("button").realHover({ position: "bottomLeft" }) // hovers over the bottom left corner of button
 ```
@@ -294,13 +295,13 @@ Options:
 - `Optional` **scrollBehavior**: "center" | "top" | "bottom" | "nearest" | false
 
 ## FAQ
-   
+
 1. Why `.realHover` hovering state does not show in the visual regression services?
 
-Unforunately, visual regression services like Happo and Percy does not solve this issue. Thier architecture is based on saving dom snapshot, not the screenshot and then rendering the snapshot on thier machines. It means that hover and focus state will be lost if it won't be serialized manually. 
+Unforunately, visual regression services like Happo and Percy does not solve this issue. Thier architecture is based on saving dom snapshot, not the screenshot and then rendering the snapshot on thier machines. It means that hover and focus state will be lost if it won't be serialized manually.
 
 In fact it means that if you will use plain `cy.screenshot` it will render screenshot with hovering state because using browser itself to make a screenshot. Testing hovering state is possible with, for example, [Visual Regression Tracker](https://github.com/Visual-Regression-Tracker/Visual-Regression-Tracker) and [cypress-image-snapshot](https://github.com/jaredpalmer/cypress-image-snapshot).
-   
+
 ## UX
 
 One problem of the real native system events I need to mention – you will not get an error message if the event wasn't produced. Similar to selenium or playwright – if a javascript event was not fired you will not get a comprehensive error message.

--- a/cypress/integration/click.spec.ts
+++ b/cypress/integration/click.spec.ts
@@ -40,6 +40,16 @@ describe("cy.realClick", () => {
     cy.get(".action-btn").realClick({ button: "right" });
   });
 
+  it("allow for double clicks", (done) => {
+    cy.get(".action-btn")
+      .then(($button) => {
+        $button.get(0).addEventListener("dblclick", () => {
+          done()
+        });
+      })
+      .realClick({ clickCount: 2 });
+  });
+
   describe("scroll behavior", () => {
     function getScreenEdges() {
       const cypressAppWindow = window.parent.document.querySelector("iframe")

--- a/src/commands/realClick.ts
+++ b/src/commands/realClick.ts
@@ -29,9 +29,14 @@ export interface RealClickOptions {
   y?: number;
   /**
    * Controls how the page is scrolled to bring the subject into view, if needed.
-   * @example cy.realHover({ scrollBehavior: "top" });
+   * @example cy.realClick({ scrollBehavior: "top" });
    */
   scrollBehavior?: ScrollBehaviorOptions;
+  /**
+   * Controls how many times pointer gets clicked. It can be used to simulate double clicks.
+   * @example cy.realClick({ clickCount: 2 });
+   */
+  clickCount?: number
 }
 
 /** @ignore this, update documentation for this function at index.d.ts */
@@ -40,8 +45,8 @@ export async function realClick(
   options: RealClickOptions = {}
 ) {
   // prettier-ignore
-  const position = options.x && options.y 
-    ? { x: options.x, y: options.y } 
+  const position = options.x && options.y
+    ? { x: options.x, y: options.y }
     : options.position;
 
   const { x, y } = getCypressElementCoordinates(subject, position, options.scrollBehavior);
@@ -60,7 +65,7 @@ export async function realClick(
     type: "mousePressed",
     x,
     y,
-    clickCount: 1,
+    clickCount: options.clickCount ?? 1,
     buttons: 1,
     pointerType: options.pointer ?? "mouse",
     button: options.button ?? "left",
@@ -70,7 +75,7 @@ export async function realClick(
     type: "mouseReleased",
     x,
     y,
-    clickCount: 1,
+    clickCount: options.clickCount ?? 1,
     buttons: 1,
     pointerType: options.pointer ?? "mouse",
     button: options.button ?? "left",


### PR DESCRIPTION
I'm slightly unsure how this works under the hood - since both `mousePressed` & `mouseReleased` expects this parameter. I don't know what actually happens if you configure a different `clickCount` for each of those but I've tested that both are required to make this work.