### PR TITLE
Add "Backspace" to keyCodeDefinitions.ts

### DIFF
--- a/src/keyCodeDefinitions.ts
+++ b/src/keyCodeDefinitions.ts
@@ -17,6 +17,7 @@ export const keyCodeDefinitions =  {
   'Abort': {'keyCode': 3, 'code': 'Abort', 'key': 'Cancel'},
   'Help': {'keyCode': 6, 'code': 'Help', 'key': 'Help'},
   '{backspace}': {'keyCode': 8, 'code': 'Backspace', 'key': 'Backspace'},
+  'Backspace': {'keyCode': 8, 'code': 'Backspace', 'key': 'Backspace'},
   'Tab': {'keyCode': 9, 'code': 'Tab', 'key': 'Tab'},
   'Numpad5': {'keyCode': 12, 'shiftKeyCode': 101, 'key': 'Clear', 'code': 'Numpad5', 'shiftKey': '5', 'location': 3},
   'NumpadEnter': {'keyCode': 13, 'code': 'NumpadEnter', 'key': 'Enter', 'location': 3},


### PR DESCRIPTION
Thanks for all the hard work :)

Currently all functional keys have two variants their literal name e.g. "Enter" and their escaped version "{enter}". The only key that doesn't follow this pattern and only provides an escaped variant is "Backspace". It would be good to add the ability to write:

```js
cy.realPress("Backspace");
```