### PR TITLE
fix typo in cy.realMouseMove code example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ cy.get("sector").realMouseMove(x, y, options);
 Example:
 
 ```js
-cy.get("sector").realMouseUp(50, 50, { position: "center" }); // moves by 50px x and y from center of sector
+cy.get("sector").realMouseMove(50, 50, { position: "center" }); // moves by 50px x and y from center of sector
 ```
 
 Options:


### PR DESCRIPTION
The code example for `cy.realMouseMove` is using `cy,realMouseUp`

Currently the code example for `cy.realMouseMove` in README.md is:

```js
cy.get("sector").realMouseUp(50, 50, { position: "center" }); // moves by 50px x and y from center of sector
```

I think the correct example should be:

```js
cy.get("sector").realMouseMove(50, 50, { position: "center" }); // moves by 50px x and y from center of sector
```

Link to relevant README section https://github.com/dmtrKovalenko/cypress-real-events#cyrealmousemove

Link to the specific text I'm referring to: https://github.com/dmtrKovalenko/cypress-real-events#:~:text=cy.get(%22sector%22).-,realmouseup(50%2C%2050,-%2C%20%7B%20position%3A%20%22center%22%20%7D)%3B%20%2F%2F%20moves

Closes #232 

Thanks again for creating and maintaining such a useful Cypress plugin!

