### PR TITLE
fix: strict top offset comparison fails in headed mode

### DIFF
--- a/cypress/integration/click.spec.ts
+++ b/cypress/integration/click.spec.ts
@@ -99,7 +99,7 @@ describe("cy.realClick", () => {
           const { top: $elTop } = getElementEdges($canvas);
           const { top: screenTop } = getScreenEdges();
 
-          expect($elTop).to.equal(screenTop);
+          expect($elTop).to.be.closeTo(screenTop, 1);
         });
     });
 
@@ -112,8 +112,8 @@ describe("cy.realClick", () => {
 
           const screenCenter = screenTop + (screenBottom - screenTop) / 2;
 
-          expect($elTop).to.equal(screenCenter - $canvas.outerHeight() / 2);
-          expect($elBottom).to.equal(screenCenter + $canvas.outerHeight() / 2);
+          expect($elTop).to.be.closeTo(screenCenter - $canvas.outerHeight() / 2, 1);
+          expect($elBottom).to.be.closeTo(screenCenter + $canvas.outerHeight() / 2, 1);
         });
     });
 
@@ -124,7 +124,7 @@ describe("cy.realClick", () => {
           const { top: $elTop } = getElementEdges($canvas);
           const { top: screenTop } = getScreenEdges();
 
-          expect($elTop).to.equal(screenTop);
+          expect($elTop).to.be.closeTo(screenTop, 1);
         });
     });
 
@@ -135,7 +135,7 @@ describe("cy.realClick", () => {
           const { bottom: $elBottom } = getElementEdges($canvas);
           const { bottom: screenBottom } = getScreenEdges();
 
-          expect($elBottom).to.equal(screenBottom);
+          expect($elBottom).to.be.closeTo(screenBottom, 1);
         });
     });
 
@@ -148,7 +148,7 @@ describe("cy.realClick", () => {
           const { top: $elTop } = getElementEdges($canvas);
           const { top: screenTop } = getScreenEdges();
 
-          expect($elTop).to.equal(screenTop);
+          expect($elTop).to.be.closeTo(screenTop, 1);
         });
 
       cy.window().scrollTo("top");
@@ -159,7 +159,7 @@ describe("cy.realClick", () => {
           const { bottom: $elBottom } = getElementEdges($canvas);
           const { bottom: screenBottom } = getScreenEdges();
 
-          expect($elBottom).to.equal(screenBottom);
+          expect($elBottom).to.be.closeTo(screenBottom, 1);
         });
     });
   });

--- a/cypress/integration/hover.spec.ts
+++ b/cypress/integration/hover.spec.ts
@@ -52,7 +52,7 @@ describe("cy.realHover", () => {
           const { $elTop } = getElementEdges($canvas);
           const { screenTop } = getScreenEdges();
 
-          expect($elTop).to.equal(screenTop);
+          expect($elTop).to.be.closeTo(screenTop, 1);
         });
     });
 
@@ -65,8 +65,8 @@ describe("cy.realHover", () => {
 
           const screenCenter = screenTop + (screenBottom - screenTop) / 2;
 
-          expect($elTop).to.equal(screenCenter - $canvas.outerHeight() / 2);
-          expect($elBottom).to.equal(screenCenter + $canvas.outerHeight() / 2);
+          expect($elTop).to.be.closeTo(screenCenter - $canvas.outerHeight() / 2, 1);
+          expect($elBottom).to.be.closeTo(screenCenter + $canvas.outerHeight() / 2, 1);
         });
     });
 
@@ -77,7 +77,7 @@ describe("cy.realHover", () => {
           const { $elTop } = getElementEdges($canvas);
           const { screenTop } = getScreenEdges();
 
-          expect($elTop).to.equal(screenTop);
+          expect($elTop).to.be.closeTo(screenTop, 1);
         });
     });
 
@@ -88,7 +88,7 @@ describe("cy.realHover", () => {
           const { $elBottom } = getElementEdges($canvas);
           const { screenBottom } = getScreenEdges();
 
-          expect($elBottom).to.equal(screenBottom);
+          expect($elBottom).to.be.closeTo(screenBottom, 1);
         });
     });
 
@@ -101,7 +101,7 @@ describe("cy.realHover", () => {
           const { $elTop } = getElementEdges($canvas);
           const { screenTop } = getScreenEdges();
 
-          expect($elTop).to.equal(screenTop);
+          expect($elTop).to.be.closeTo(screenTop, 1);
         });
 
       cy.window().scrollTo("top");
@@ -112,7 +112,7 @@ describe("cy.realHover", () => {
           const { $elBottom } = getElementEdges($canvas);
           const { screenBottom } = getScreenEdges();
 
-          expect($elBottom).to.equal(screenBottom);
+          expect($elBottom).to.be.closeTo(screenBottom, 1);
         });
     });
   });

--- a/cypress/integration/mouse.spec.ts
+++ b/cypress/integration/mouse.spec.ts
@@ -110,7 +110,7 @@ describe("cy.realMouseDown and cy.realMouseUp", () => {
           const { top: $elTop } = getElementEdges($canvas);
           const { top: screenTop } = getScreenEdges();
 
-          expect($elTop).to.equal(screenTop);
+          expect($elTop).to.be.closeTo(screenTop, 1);
         });
     });
 
@@ -123,8 +123,8 @@ describe("cy.realMouseDown and cy.realMouseUp", () => {
 
           const screenCenter = screenTop + (screenBottom - screenTop) / 2;
 
-          expect($elTop).to.equal(screenCenter - $canvas.outerHeight() / 2);
-          expect($elBottom).to.equal(screenCenter + $canvas.outerHeight() / 2);
+          expect($elTop).to.be.closeTo(screenCenter - $canvas.outerHeight() / 2, 1);
+          expect($elBottom).to.be.closeTo(screenCenter + $canvas.outerHeight() / 2, 1);
         });
     });
 
@@ -135,7 +135,7 @@ describe("cy.realMouseDown and cy.realMouseUp", () => {
           const { top: $elTop } = getElementEdges($canvas);
           const { top: screenTop } = getScreenEdges();
 
-          expect($elTop).to.equal(screenTop);
+          expect($elTop).to.be.closeTo(screenTop, 1);
         });
     });
 
@@ -146,7 +146,7 @@ describe("cy.realMouseDown and cy.realMouseUp", () => {
           const { bottom: $elBottom } = getElementEdges($canvas);
           const { bottom: screenBottom } = getScreenEdges();
 
-          expect($elBottom).to.equal(screenBottom);
+          expect($elBottom).to.be.closeTo(screenBottom, 1);
         });
     });
 
@@ -159,7 +159,7 @@ describe("cy.realMouseDown and cy.realMouseUp", () => {
           const { top: $elTop } = getElementEdges($canvas);
           const { top: screenTop } = getScreenEdges();
 
-          expect($elTop).to.equal(screenTop);
+          expect($elTop).to.be.closeTo(screenTop, 1);
         });
 
       cy.window().scrollTo("top");
@@ -170,7 +170,7 @@ describe("cy.realMouseDown and cy.realMouseUp", () => {
           const { bottom: $elBottom } = getElementEdges($canvas);
           const { bottom: screenBottom } = getScreenEdges();
 
-          expect($elBottom).to.equal(screenBottom);
+          expect($elBottom).to.be.closeTo(screenBottom, 1);
         });
     });
   });
@@ -210,7 +210,7 @@ describe("cy.realMouseDown and cy.realMouseUp", () => {
           const { top: $elTop } = getElementEdges($canvas);
           const { top: screenTop } = getScreenEdges();
 
-          expect($elTop).to.equal(screenTop);
+          expect($elTop).to.be.closeTo(screenTop, 1);
         });
     });
 
@@ -223,8 +223,8 @@ describe("cy.realMouseDown and cy.realMouseUp", () => {
 
           const screenCenter = screenTop + (screenBottom - screenTop) / 2;
 
-          expect($elTop).to.equal(screenCenter - $canvas.outerHeight() / 2);
-          expect($elBottom).to.equal(screenCenter + $canvas.outerHeight() / 2);
+          expect($elTop).to.be.closeTo(screenCenter - $canvas.outerHeight() / 2, 1);
+          expect($elBottom).to.be.closeTo(screenCenter + $canvas.outerHeight() / 2, 1);
         });
     });
 
@@ -235,7 +235,7 @@ describe("cy.realMouseDown and cy.realMouseUp", () => {
           const { top: $elTop } = getElementEdges($canvas);
           const { top: screenTop } = getScreenEdges();
 
-          expect($elTop).to.equal(screenTop);
+          expect($elTop).to.be.closeTo(screenTop, 1);
         });
     });
 
@@ -246,7 +246,7 @@ describe("cy.realMouseDown and cy.realMouseUp", () => {
           const { bottom: $elBottom } = getElementEdges($canvas);
           const { bottom: screenBottom } = getScreenEdges();
 
-          expect($elBottom).to.equal(screenBottom);
+          expect($elBottom).to.be.closeTo(screenBottom, 1);
         });
     });
 
@@ -259,7 +259,7 @@ describe("cy.realMouseDown and cy.realMouseUp", () => {
           const { top: $elTop } = getElementEdges($canvas);
           const { top: screenTop } = getScreenEdges();
 
-          expect($elTop).to.equal(screenTop);
+          expect($elTop).to.be.closeTo(screenTop, 1);
         });
 
       cy.window().scrollTo("top");
@@ -270,7 +270,7 @@ describe("cy.realMouseDown and cy.realMouseUp", () => {
           const { bottom: $elBottom } = getElementEdges($canvas);
           const { bottom: screenBottom } = getScreenEdges();
 
-          expect($elBottom).to.equal(screenBottom);
+          expect($elBottom).to.be.closeTo(screenBottom, 1);
         });
     });
   });


### PR DESCRIPTION
Many tests were failing in `click.spec.ts`, `hover.spec.ts`, and `mouse.spec.ts` when I ran them locally in the Cypress Test Runner using the `yarn run cypress open` command. Please see the screenshots below.

All tests passed in headless mode.

The reason for the headed failures are that the top offset of the element is expected to be an integer but the actual value has a decimal of usually 0.1875.

The fix seems quite easy and works well for me locally. I just changed the Cypress comparison to allow for the small deviation. It seems like a relatively safe change.

Please let me know if I missed something.

<img width="564" alt="image" src="https://user-images.githubusercontent.com/24983797/154049701-1cac293c-52ce-4356-b64e-59c4bca30820.png">

![image](https://user-images.githubusercontent.com/24983797/154046162-28c52563-632b-48f3-a9b4-dc10bf180793.png)

![image](https://user-images.githubusercontent.com/24983797/154046479-136b6bcd-43cd-499d-a090-471e1897c43c.png)

![image](https://user-images.githubusercontent.com/24983797/154046673-3a53c616-87c2-4ea4-a851-602cd372c1ff.png)

![image](https://user-images.githubusercontent.com/24983797/154046338-f7ffac76-1285-47e2-b5b8-16c188341aae.png)
