### PR TITLE
docs: Simplify Typescript instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,17 +64,7 @@ yarn add cypress-real-events
 Register new commands by adding this to your `cypress/support/index.{js,ts}` file.
 
 ```js
-import "cypress-real-events/support";
-```
-
-If you are using typescript, also add the following to `cypress/tsconfig.json`
-
-```json
-{
-  "compilerOptions": {
-    "types": ["cypress", "cypress-real-events"]
-  }
-}
+import "cypress-real-events";
 ```
 
 ## API


### PR DESCRIPTION
Remove the `/support` in the import instructions removes the need to modify the `tsconfig.json` file.

While following the instructions, I noticed the `package.json` has a `main` entry that points to the `support.js` file while the `types` points to the `index.d.ts` file. Removing the `/support` from the instructions removes the need to modify the `"types"` in the `tsconfig.json` file. It makes everything simpler.