### PR TITLE
Add support for x/y options to realMouseDown and realMouseUp.

### DIFF
--- a/cypress/e2e/mouse.cy.ts
+++ b/cypress/e2e/mouse.cy.ts
@@ -46,7 +46,9 @@ describe("cy.realMouseDown and cy.realMouseUp", () => {
       .realMouseDown({ position: "bottom" })
       .realMouseUp({ position: "bottom" })
       .realMouseDown({ position: "bottomRight" })
-      .realMouseUp({ position: "bottomRight" });
+      .realMouseUp({ position: "bottomRight" })
+      .realMouseDown({ x: 5, y: 5 })
+      .realMouseUp({ x: 5, y: 5 });
   });
 
   describe("options.button", () => {

--- a/src/commands/mouseDown.ts
+++ b/src/commands/mouseDown.ts
@@ -15,11 +15,17 @@ export interface realMouseDownOptions {
    */
   position?: Position;
   /**
+   * X and Y location of the realMouseDown event relative to the position.
+   * Changes the default value of position to "topLeft" if either are set.
+   * @example cy.realMouseDown({ x: 100, y: 100 })
+   */
+  x?: number;
+  y?: number;
+  /**
    * Controls how the page is scrolled to bring the subject into view, if needed.
    * @example cy.realMouseDown({ scrollBehavior: "top" });
    */
   scrollBehavior?: ScrollBehaviorOptions;
-
   /**
    * @default "left"
    */
@@ -31,7 +37,14 @@ export async function realMouseDown(
   subject: JQuery,
   options: realMouseDownOptions = {}
 ) {
-  const { x, y } = getCypressElementCoordinates(subject, options.position, options.scrollBehavior);
+  // Default position to "topLeft" if x or y are set.
+  const position = options.x != null || options.y != null
+    ? options.position ?? 'topLeft'
+    : options.position;
+
+  let { x, y } = getCypressElementCoordinates(subject, position, options.scrollBehavior);
+  x += options.x ?? 0;
+  y += options.y ?? 0;
 
   const log = Cypress.log({
     $el: subject,

--- a/src/commands/mouseUp.ts
+++ b/src/commands/mouseUp.ts
@@ -15,6 +15,13 @@ export interface realMouseUpOptions {
    */
   position?: Position;
   /**
+   * X and Y location of the realMouseUp event relative to the position.
+   * Changes the default value of position to "topLeft" if either are set.
+   * @example cy.realMouseUp({ x: 100, y: 100 })
+   */
+  x?: number;
+  y?: number;
+  /**
    * Controls how the page is scrolled to bring the subject into view, if needed.
    * @example cy.realMouseUp({ scrollBehavior: "top" });
    */
@@ -30,7 +37,14 @@ export async function realMouseUp(
   subject: JQuery,
   options: realMouseUpOptions = {}
 ) {
-  const { x, y } = getCypressElementCoordinates(subject, options.position, options.scrollBehavior);
+  // Default position to "topLeft" if x or y are set.
+  const position = options.x != null || options.y != null
+    ? options.position ?? 'topLeft'
+    : options.position;
+
+  let { x, y } = getCypressElementCoordinates(subject, position, options.scrollBehavior);
+  x += options.x ?? 0;
+  y += options.y ?? 0;
 
   const log = Cypress.log({
     $el: subject,


### PR DESCRIPTION
https://github.com/dmtrKovalenko/cypress-real-events/issues/316

This is what I've ended up using in a forked version of realMouseDown in my project for testing some canvas interactions. Let me know if there's anything else I need to add!