### PR TITLE
fix: added check to filter possible iframe undefined values

### DIFF
--- a/src/getCypressElementCoordinates.ts
+++ b/src/getCypressElementCoordinates.ts
@@ -102,7 +102,10 @@ function getIframesPositionShift(element: HTMLElement) {
   const iframes = [];
 
   while (currentWindow !== window.top) {
-    iframes.push(getFrameElement(currentWindow));
+    var iframe = getFrameElement(currentWindow)
+    if(iframe) {
+        iframes.push(iframe);
+    }
     currentWindow = currentWindow.parent;
   }
 


### PR DESCRIPTION
Cypress Version 11.1.0 (11.1.0.1925890) catches undefined error during nx cypress component testing, specifically for **realHover** case.

This check filters cases when the testable iframe element is not available.

The fix is tested internally on more than 200 visual regression tests.

<img width="563" alt="Screenshot 2022-11-21 at 2 16 19 PM" src="https://user-images.githubusercontent.com/733224/203140793-59a7694e-464f-43f1-a95a-505c66bc61b7.png">

Stacktrace:
```
at <unknown> (http://localhost:8080/__cypress/src/vendors-node_modules_cypress-real-events_support_js-node_modules_cypress_react18_dist_cypress-023da0.js:1212:39)
    at Array.reduceRight (<anonymous>)
    at getIframesPositionShift (http://localhost:8080/__cypress/src/vendors-node_modules_cypress-real-events_support_js-node_modules_cypress_react18_dist_cypress-023da0.js:1208:18)
    at getElementPositionXY (http://localhost:8080/__cypress/src/vendors-node_modules_cypress-real-events_support_js-node_modules_cypress_react18_dist_cypress-023da0.js:1233:31)
    at getCypressElementCoordinates (http://localhost:8080/__cypress/src/vendors-node_modules_cypress-real-events_support_js-node_modules_cypress_react18_dist_cypress-023da0.js:1263:31)
    at _callee$ (http://localhost:8080/__cypress/src/vendors-node_modules_cypress-real-events_support_js-node_modules_cypress_react18_dist_cypress-023da0.js:461:84)
    at tryCatch (http://localhost:8080/__cypress/src/vendors-node_modules_react_jsx-dev-runtime_js-node_modules_styled-components_dist_styled-comp-505541.js:5754:17)
    at Generator._invoke (http://localhost:8080/__cypress/src/vendors-node_modules_react_jsx-dev-runtime_js-node_modules_styled-components_dist_styled-comp-505541.js:5737:24)
    at Generator.next (http://localhost:8080/__cypress/src/vendors-node_modules_react_jsx-dev-runtime_js-node_modules_styled-components_dist_styled-comp-505541.js:5779:21)
    at <unknown> (http://localhost:8080/__cypress/src/vendors-node_modules_cypress-real-events_support_js-node_modules_cypress_react18_dist_cypress-023da0.js:440:67)
From previous event:
    at CommandQueue.runCommand (http://localhost:8080/__cypress/runner/cypress_runner.js:156524:8)
    at next (http://localhost:8080/__cypress/runner/cypress_runner.js:156684:19)
    at <unknown> (http://localhost:8080/__cypress/runner/cypress_runner.js:156706:16)
From previous event:
    at next (http://localhost:8080/__cypress/runner/cypress_runner.js:156684:39)
From previous event:
    at <unknown> (http://localhost:8080/__cypress/runner/cypress_runner.js:172145:77)
From previous event:
    at CommandQueue.run (http://localhost:8080/__cypress/runner/cypress_runner.js:172140:21)
    at CommandQueue.run (http://localhost:8080/__cypress/runner/cypress_runner.js:156756:15)
    at $Cy.runQueue (http://localhost:8080/__cypress/runner/cypress_runner.js:157795:14)
    at cy.<computed> [as get] (http://localhost:8080/__cypress/runner/cypress_runner.js:157894:12)
    at Context.<anonymous> ([webpack://@tryon-technology/design-system/./src/lib/components/avatar/avatar.component.cy.tsx:43:15](http://localhost:8080/__/#))
    at runnable.fn (http://localhost:8080/__cypress/runner/cypress_runner.js:158077:19)
    at callFn (http://localhost:8080/__cypress/runner/cypress_runner.js:107989:21)
    at ../driver/node_modules/mocha/lib/runnable.js.Runnable.run (http://localhost:8080/__cypress/runner/cypress_runner.js:107976:7)
    at <unknown> (http://localhost:8080/__cypress/runner/cypress_runner.js:165418:30)
From previous event:
    at Object.onRunnableRun (http://localhost:8080/__cypress/runner/cypress_runner.js:165403:53)
    at $Cypress.action (http://localhost:8080/__cypress/runner/cypress_runner.js:154101:28)
    at Runnable.run (http://localhost:8080/__cypress/runner/cypress_runner.js:163059:13)
    at next (http://localhost:8080/__cypress/runner/cypress_runner.js:108491:10)
    at <unknown> (http://localhost:8080/__cypress/runner/cypress_runner.js:108535:5)
    at timeslice (http://localhost:8080/__cypress/runner/cypress_runner.js:102461:27)
```
