### PR TITLE
fix: Remove prettier dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,5 @@
     "branches": [
       "main"
     ]
-  },
-  "dependencies": {
-    "prettier": "^3.0.0"
   }
 }


### PR DESCRIPTION
In #529 Prettier was added to the dev dependencies but not removed from dependencies 