### PR TITLE
fix(click): default force to .5 on mousePressed events

### DIFF
--- a/cypress/e2e/click.cy.ts
+++ b/cypress/e2e/click.cy.ts
@@ -75,6 +75,41 @@ describe("cy.realClick", () => {
     cy.get(".navbar-brand").realClick({ button: "right" });
   });
 
+  it("results in pointerdown events with the default pressure of 0.5", () => {
+    const handler = cy.stub();
+    cy.get(".action-btn")
+      .then(($button) => {
+        $button[0].addEventListener("pointerdown", (e) =>
+          handler("pointerdown", e.pressure),
+        );
+        $button[0].addEventListener("pointerup", (e) =>
+          handler("pointerup", e.pressure),
+        );
+      })
+      .realClick();
+    cy.wrap(handler).should("be.calledWith", "pointerdown", 0.5);
+    cy.wrap(handler).should("be.calledWith", "pointerup", 0);
+  });
+
+  it("allows for setting pressure of the pointerdown event", () => {
+    const handler = cy.stub();
+    cy.get(".action-btn")
+      .then(($button) => {
+        $button[0].addEventListener("pointerdown", (e) =>
+          handler("pointerdown", Math.round(e.pressure * 100) / 100),
+        );
+        $button[0].addEventListener("pointerup", (e) =>
+          handler("pointerup", Math.round(e.pressure * 100) / 100),
+        );
+      })
+      .realClick({ pressure: 0 })
+      .realClick({ pressure: 0.4 });
+    cy.wrap(handler)
+      .should("be.calledWith", "pointerdown", 0)
+      .should("be.calledWith", "pointerdown", 0.4)
+      .should("be.calledWith", "pointerup", 0);
+  });
+
   describe("scroll behavior", () => {
     function getScreenEdges() {
       const cypressAppWindow =

--- a/cypress/e2e/mouse.cy.ts
+++ b/cypress/e2e/mouse.cy.ts
@@ -49,6 +49,33 @@ describe("cy.realMouseDown and cy.realMouseUp", () => {
       .realMouseUp({ position: "bottomRight" });
   });
 
+  it("results in pointerdown events with the default pressure of 0.5", () => {
+    const handler = cy.stub();
+    cy.get(".action-btn")
+      .then(($button) => {
+        $button[0].addEventListener("pointerdown", (e) =>
+          handler("pointerdown", e.pressure),
+        );
+      })
+      .realMouseDown();
+    cy.wrap(handler).should("be.calledWith", "pointerdown", 0.5);
+  });
+
+  it("allows for setting pressure of the pointerdown event", () => {
+    const handler = cy.stub();
+    cy.get(".action-btn")
+      .then(($button) => {
+        $button[0].addEventListener("pointerdown", (e) =>
+          handler("pointerdown", Math.round(e.pressure * 100) / 100),
+        );
+      })
+      .realMouseDown({ pressure: 0 })
+      .realMouseDown({ pressure: 0.4 });
+    cy.wrap(handler)
+      .should("be.calledWith", "pointerdown", 0)
+      .should("be.calledWith", "pointerdown", 0.4);
+  });
+
   describe("options.button", () => {
     it("should allow to press down mouse using middle button", (done) => {
       cy.get(".action-btn")

--- a/src/commands/mouseDown.ts
+++ b/src/commands/mouseDown.ts
@@ -43,6 +43,14 @@ export interface realMouseDownOptions {
    * @example cy.realMouseDown({ shiftKey: true });
    */
   shiftKey?: boolean;
+  /**
+   * The normalized pressure, which has a range of [0,1]. It affects the `pressure` property of the triggered
+   * pointerdown event.
+   *
+   * @type {number}
+   * @default {0.5}
+   */
+  pressure?: number;
 }
 
 /** @ignore this, update documentation for this function at index.d.ts */
@@ -78,6 +86,7 @@ export async function realMouseDown(
     pointerType: options.pointer ?? "mouse",
     button: options.button ?? "left",
     modifiers: options.shiftKey ? keyToModifierBitMap.Shift : 0,
+    force: options.pressure ?? 0.5,
   });
 
   log.snapshot("after").end();

--- a/src/commands/realClick.ts
+++ b/src/commands/realClick.ts
@@ -44,6 +44,15 @@ export interface RealClickOptions {
    * @example cy.realClick({ shiftKey: true });
    */
   shiftKey?: boolean;
+
+  /**
+   * The normalized pressure, which has a range of [0,1]. It affects the `pressure` property of the triggered
+   * pointerdown event.
+   *
+   * @type {number}
+   * @default {0.5}
+   */
+  pressure?: number;
 }
 
 /** @ignore this, update documentation for this function at index.d.ts */
@@ -83,6 +92,7 @@ export async function realClick(
       pointerType: options.pointer ?? "mouse",
       button: options.button ?? "left",
       modifiers: options.shiftKey ? keyToModifierBitMap.Shift : 0,
+      force: options.pressure ?? 0.5,
     });
 
     await fireCdpCommand("Input.dispatchMouseEvent", {


### PR DESCRIPTION
in Chrome and Firefox, a real mouse press leads to pointerdown event with pressure set to 0.5. Setting [force](https://chromedevtools.github.io/devtools-protocol/tot/Input/#method-dispatchMouseEvent:~:text=clicked%20(default%3A%200).-,force,-number) to 0.5 matches that.

Closes #576