### PR TITLE
fix: uses pascal case for `RealMouseUpOptions' and 'RealMouseDownOptions'

### DIFF
--- a/src/commands/mouseDown.ts
+++ b/src/commands/mouseDown.ts
@@ -7,7 +7,7 @@ import {
 import { mouseButtonNumbers } from "../mouseButtonNumbers";
 import { getModifiers } from "../getModifiers";
 
-export interface realMouseDownOptions {
+export interface RealMouseDownOptions {
   /** Pointer type for realMouseDown, if "pen" touch simulated */
   pointer?: "mouse" | "pen";
   /**
@@ -59,7 +59,7 @@ export interface realMouseDownOptions {
 /** @ignore this, update documentation for this function at index.d.ts */
 export async function realMouseDown(
   subject: JQuery,
-  options: realMouseDownOptions = {},
+  options: RealMouseDownOptions = {},
 ) {
   const position =
     options.x && options.y ? { x: options.x, y: options.y } : options.position;

--- a/src/commands/mouseUp.ts
+++ b/src/commands/mouseUp.ts
@@ -7,7 +7,7 @@ import {
 import { mouseButtonNumbers } from "../mouseButtonNumbers";
 import { getModifiers } from "../getModifiers";
 
-export interface realMouseUpOptions {
+export interface RealMouseUpOptions {
   /** Pointer type for realMouseUp, if "pen" touch simulated */
   pointer?: "mouse" | "pen";
   /**
@@ -49,7 +49,7 @@ export interface realMouseUpOptions {
 /** @ignore this, update documentation for this function at index.d.ts */
 export async function realMouseUp(
   subject: JQuery,
-  options: realMouseUpOptions = {},
+  options: RealMouseUpOptions = {},
 ) {
   const position =
     options.x && options.y ? { x: options.x, y: options.y } : options.position;


### PR DESCRIPTION
Resolves #611 

This is somewhat of a breaking change - maybe should not be included until the next major release.