### PR TITLE
Support brackets in real type

### DIFF
--- a/src/commands/realType.ts
+++ b/src/commands/realType.ts
@@ -47,7 +47,7 @@ export async function realType(text: string, options: RealTypeOptions = {}) {
     .split(/({.+?})/)
     .filter(Boolean)
     .reduce((acc, group) => {
-      return /({.+?})/.test(group)
+      return /({.+?})/.test(group) && availableChars.includes(group)
         ? [...acc, group]
         : [...acc, ...group.split("")];
     }, [] as string[]);


### PR DESCRIPTION
Currently, using `realType('A {random string}')` throw an error, instead of just inserting the string as is